### PR TITLE
change jest to vi in tests

### DIFF
--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
-import '@testing-library/jest-dom'
-import jest from 'jest-mock'
+import { vi } from 'vitest'
 
 const switchOptions = {
   left: { text: 'Left Option', tooltip: 'Left tooltip' },
@@ -13,7 +12,7 @@ describe('AppContentSwitcher', () => {
     render(
       <AppContentSwitcher
         active
-        onChange={jest.fn()}
+        onChange={vi.fn()}
         switchOptions={switchOptions}
         typographyVariant='body1'
       />
@@ -25,7 +24,7 @@ describe('AppContentSwitcher', () => {
   })
 
   it('should call the onChange function when the switch is clicked', () => {
-    const handleChange = jest.fn()
+    const handleChange = vi.fn()
 
     render(
       <AppContentSwitcher
@@ -45,7 +44,7 @@ describe('AppContentSwitcher', () => {
     render(
       <AppContentSwitcher
         active
-        onChange={jest.fn()}
+        onChange={vi.fn()}
         switchOptions={switchOptions}
         typographyVariant='body1'
       />


### PR DESCRIPTION
fix tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test mocks to use Vitest instead of Jest for improved compatibility with the current testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->