### PR TITLE
#230: Fix send a request item

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -49,7 +49,7 @@
         "description": "Finding a tutor is very easy, select a subject from the list, and then pick the tutor, or enter his name and find directly."
       },
       "sendRequest": {
-        "title": "Send Request",
+        "title": "Send a Request",
         "description": "Write a request to the tutor in two clicks, where you indicate/confirm the price and the desired level of training."
       },
       "startLearning": {


### PR DESCRIPTION
The “Send a Request” item in the student registration option at the home page “How it works” block is matched to the mockup.
![send-a-request](https://github.com/user-attachments/assets/ed3b9c6f-2e6c-4486-9d35-7b7b61da0020)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the wording of the "Send Request" title to "Send a Request" in the guest home page for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->