### PR TITLE
77: Add validation to required fields in General info step

### DIFF
--- a/src/components/step-wrapper/StepWrapper.jsx
+++ b/src/components/step-wrapper/StepWrapper.jsx
@@ -1,4 +1,4 @@
-import { cloneElement, useEffect } from 'react'
+import { cloneElement, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Container from '@mui/material/Container'
@@ -18,11 +18,15 @@ const StepWrapper = ({ children, steps, onStepChange }) => {
     })
   const { next, back, setActiveStep, handleSubmit } = stepOperation
   const { t } = useTranslation()
+  const [stepErrorState, setStepErrorState] = useState(false)
   useEffect(() => {
     if (onStepChange) {
       onStepChange(activeStep)
     }
   }, [activeStep, onStepChange])
+
+  const isNextDisabled = stepErrorState || stepErrors[activeStep]
+
   const stepLabels = steps.map((step, index) => (
     <Box
       color={stepErrors[index] ? 'error.500' : 'primary.500'}
@@ -37,6 +41,7 @@ const StepWrapper = ({ children, steps, onStepChange }) => {
 
   const nextButton = isLastStep ? (
     <AppButton
+      disabled={loading}
       loading={loading}
       onClick={handleSubmit}
       size='small'
@@ -47,6 +52,7 @@ const StepWrapper = ({ children, steps, onStepChange }) => {
     </AppButton>
   ) : (
     <AppButton
+      disabled={isNextDisabled}
       onClick={next}
       size='small'
       sx={styles.btnRight}
@@ -79,7 +85,8 @@ const StepWrapper = ({ children, steps, onStepChange }) => {
       <Box sx={styles.stepContent}>
         {cloneElement(children[activeStep], {
           btnsBox,
-          stepLabel: steps[activeStep]
+          stepLabel: steps[activeStep],
+          onErrorChange: setStepErrorState
         })}
       </Box>
     </Container>

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
@@ -8,7 +8,7 @@ import Checkbox from '@mui/material/Checkbox'
 
 import { styles } from '~/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles'
 
-const GeneralInfoStep = ({ btnsBox }) => {
+const GeneralInfoStep = ({ btnsBox, onErrorChange }) => {
   const countries = ['USA', 'Canada', 'UK']
   const cities = ['New York', 'Toronto', 'London']
   const [form, setForm] = useState({
@@ -19,6 +19,11 @@ const GeneralInfoStep = ({ btnsBox }) => {
     description: '',
     confirmAge: false
   })
+  const [errors, setErrors] = useState({
+    firstName: false,
+    lastName: false,
+    description: false
+  })
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target
@@ -27,6 +32,23 @@ const GeneralInfoStep = ({ btnsBox }) => {
       [name]: type === 'checkbox' ? checked : value
     }))
   }
+
+  const validateForm = () => {
+    const newErrors = {
+      firstName: form.firstName === '',
+      lastName: form.lastName === '',
+      description: form.description.length > 100
+    }
+    setErrors(newErrors)
+    onErrorChange(Object.values(newErrors).includes(true))
+  }
+  const handleDescriptionChange = (e) => {
+    const { value } = e.target
+    if (value.length <= 100) {
+      setForm((prev) => ({ ...prev, description: value }))
+    }
+  }
+
   return (
     <>
       <Typography variant='body1'>
@@ -35,17 +57,23 @@ const GeneralInfoStep = ({ btnsBox }) => {
       </Typography>
       <Box sx={styles.inputs}>
         <TextField
+          error={errors.firstName}
           fullWidth
+          helperText={errors.firstName && 'First name is required'}
           label='First Name'
           name='firstName'
+          onBlur={() => validateForm()}
           onChange={handleChange}
           required
           value={form.firstName}
         />
         <TextField
+          error={errors.lastName}
           fullWidth
+          helperText={errors.lastName && 'Last name is required'}
           label='Last Name'
           name='lastName'
+          onBlur={() => validateForm()}
           onChange={handleChange}
           required
           value={form.lastName}
@@ -82,13 +110,14 @@ const GeneralInfoStep = ({ btnsBox }) => {
         </TextField>
       </Box>
       <TextField
+        error={errors.description}
         fullWidth
-        helperText={`${form.description.length}/200`}
-        inputProps={{ maxLength: 200 }}
+        helperText={`${form.description.length}/100`}
+        inputProps={{ maxLength: 100 }}
         label='Describe in short your professional status'
         multiline
         name='description'
-        onChange={handleChange}
+        onChange={handleDescriptionChange}
         rows={3}
         value={form.description}
       />


### PR DESCRIPTION
Add validation to the required fields in General info step and accomplished the following tasks: 

1. First name and Last name fields must be required and show an error when user removed text from them

2. Length of additional info can't be more than 100 symbols and block texting when it reached limit

3. When there are errors in required fields stepper can't be finished

![validation-generalInfoStep](https://github.com/user-attachments/assets/8c428247-f3a6-41b0-b31b-66ed156957fc)