### PR TITLE
#109: Add list grid switcher buttons

### DIFF
--- a/src/components/listGridSwitch/ListGridSwitch.jsx
+++ b/src/components/listGridSwitch/ListGridSwitch.jsx
@@ -1,0 +1,29 @@
+import { ToggleButtonGroup, ToggleButton } from '@mui/material'
+import ListIcon from '@mui/icons-material/List'
+import GridViewIcon from '@mui/icons-material/GridView'
+
+const ListGridSwitch = ({ isGrid, setIsGrid }) => {
+  const handleChange = (_, newValue) => {
+    if (newValue !== null) {
+      setIsGrid(newValue)
+    }
+  }
+  return (
+    <ToggleButtonGroup
+      aria-label='View toggle'
+      exclusive
+      onChange={handleChange}
+      size='small'
+      value={isGrid}
+    >
+      <ToggleButton aria-label='List view' value={false}>
+        <ListIcon sx={{ mr: 1 }} />
+      </ToggleButton>
+      <ToggleButton aria-label='Grid view' value>
+        <GridViewIcon sx={{ mr: 1 }} />
+      </ToggleButton>
+    </ToggleButtonGroup>
+  )
+}
+
+export default ListGridSwitch


### PR DESCRIPTION
Added the ListGridSwitch component button, to toggle between the list and grid view of the offer cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a toggle switch allowing users to easily switch between list and grid views, with accessible icons for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->