### PR TITLE
#267: Fix the width of the rectangle and square cards

### DIFF
--- a/src/components/offer-card/offer-card-rectangle/OfferCardRectangle.styles.js
+++ b/src/components/offer-card/offer-card-rectangle/OfferCardRectangle.styles.js
@@ -5,12 +5,11 @@ export const styles = {
     p: { xs: 1, sm: 2, md: 3 },
     borderRadius: 3,
     boxShadow: 3,
+    boxSizing: 'border-box',
     width: '100%',
-    maxWidth: { xs: '100%', sm: '95%', md: '900px' },
-    ml: 'auto',
-    mr: '100px',
+    maxWidth: '100%',
     mb: { xs: 4, sm: 5 },
-    overflowX: 'visible'
+    overflowX: 'hidden'
   },
   leftColumn: {
     display: 'flex',

--- a/src/components/offer-card/offer-card-rectangle/UserProfile.jsx
+++ b/src/components/offer-card/offer-card-rectangle/UserProfile.jsx
@@ -1,17 +1,17 @@
 import { Box, Typography, Avatar, Rating } from '@mui/material'
 import { useTranslation } from 'react-i18next'
+import avatar from '~/assets/img/tutor-profile-page/avatar.png'
 import { styles } from '~/components/offer-card/offer-card-rectangle/OfferCardRectangle.styles'
 
 const UserProfile = ({
   name = 'Jennifer W.',
-  avatarSrc = '/src/assets/img/tutor-profile-page/avatar.png',
   rating = 5,
   reviewCount = 10
 }) => {
   const { t } = useTranslation()
   return (
     <Box sx={styles.leftColumn}>
-      <Avatar src={avatarSrc} sx={styles.avatar} />
+      <Avatar src={avatar} sx={styles.avatar} />
       <Typography color='primary.500' fontWeight='500' variant='subtitle1'>
         {name}
       </Typography>

--- a/src/components/offer-card/offer-card-square/OfferCardSquare.styles.js
+++ b/src/components/offer-card/offer-card-square/OfferCardSquare.styles.js
@@ -2,15 +2,16 @@ import { lightGreen } from '@mui/material/colors'
 
 export const styles = {
   card: {
-    width: 360,
-    p: 2,
+    width: '100%',
+    height: '100%',
+    boxSizing: 'border-box',
+    p: 4,
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
     gap: 2,
     borderRadius: 3,
     boxShadow: 4,
-    mx: 'auto',
     my: 4
   },
   topRow: {

--- a/src/components/offer-card/offer-card-square/UserProfileSquare.jsx
+++ b/src/components/offer-card/offer-card-square/UserProfileSquare.jsx
@@ -3,18 +3,19 @@ import { Box, Avatar, Typography, IconButton } from '@mui/material'
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
 import LanguageIcon from '@mui/icons-material/Language'
 
+import avatar from '~/assets/img/tutor-profile-page/avatar.png'
+
 import { styles } from '~/components/offer-card/offer-card-square/OfferCardSquare.styles'
 
 const UserProfileSquare = ({
   name = 'Jennifer Wilsonsontelberg',
-  avatarSrc = '/src/assets/img/tutor-profile-page/avatar.png',
   spokenLanguages = 'Ukrainian',
   onAddToWishlist
 }) => {
   return (
     <Box sx={styles.topRow}>
       <Box sx={styles.profileLeft}>
-        <Avatar src={avatarSrc} sx={styles.avatar} />
+        <Avatar src={avatar} sx={styles.avatar} />
         <Box sx={styles.nameSection}>
           <Typography sx={styles.name} variant='subtitle1'>
             {name}

--- a/src/components/offers-container/OffersContainer.jsx
+++ b/src/components/offers-container/OffersContainer.jsx
@@ -1,33 +1,23 @@
-import { Box } from '@mui/material'
+import { Grid } from '@mui/material'
 
 import OfferCardSquare from '~/components/offer-card/offer-card-square/OfferCardSquare'
 import OfferCardRectangle from '~/components/offer-card/offer-card-rectangle/OfferCardRectangle'
 
 const OffersContainer = ({ offers, isGrid }) => {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: isGrid ? 'row' : 'column',
-        flexWrap: 'wrap',
-        gap: 2,
-        mt: 2
-      }}
-    >
+    <Grid container mt={2} spacing={2}>
       {offers.map((item) =>
         isGrid ? (
-          <Box key={item.id} sx={{ flex: '1 1 calc(33.333% - 16px)' }}>
+          <Grid item key={item.id} md={4} sm={6} xs={12}>
             <OfferCardSquare author={item.author} offer={item.offer} />
-          </Box>
+          </Grid>
         ) : (
-          <OfferCardRectangle
-            author={item.author}
-            key={item.id}
-            offer={item.offer}
-          />
+          <Grid item key={item.id} xs={12}>
+            <OfferCardRectangle author={item.author} offer={item.offer} />
+          </Grid>
         )
       )}
-    </Box>
+    </Grid>
   )
 }
 

--- a/src/containers/find-offer/offers-block/OffersBlock.jsx
+++ b/src/containers/find-offer/offers-block/OffersBlock.jsx
@@ -2,14 +2,14 @@ import React, { useState } from 'react'
 import { Box } from '@mui/material'
 import { mockOffers } from '~/containers/find-offer/offers-block/__mocks__/mockOffers'
 
-import ListGridSwitcher from '~/components/listGridSwitch/ListGridSwitch'
+import ListGridSwitcher from '~/components/listGridSwitch/listGridSwitch'
 import OffersContainer from '~/components/offers-container/OffersContainer'
 
 const OffersBlock = () => {
   const [isGrid, setIsGrid] = useState(false)
 
   return (
-    <Box sx={{ p: 3 }}>
+    <Box sx={{ p: 0 }}>
       <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
         <ListGridSwitcher isGrid={isGrid} setIsGrid={setIsGrid} />
       </Box>

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import MenuItem from '@mui/material/MenuItem'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Checkbox from '@mui/material/Checkbox'
 


### PR DESCRIPTION
Fixed the width of the rectangle card and now it has the same width as a container. Removed the fixed width of te square card and now it has the width as a container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved card and profile component styles for more consistent sizing, padding, and overflow handling.
  - Enhanced layout of offer cards by switching to a grid-based system for better responsiveness.
- **Refactor**
  - Simplified avatar handling in user profile components by directly importing static images.
  - Updated import paths and removed unused imports for cleaner code.
- **Chores**
  - Minor adjustments to component structure and styling for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->